### PR TITLE
Fix express server serve built client

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ npm run dev
 Vite will provide a local development URL (usually http://localhost:5173).
 
 ## Building the client for production
-From the `client` directory, run:
+To create a production build of the client, run the following from the
+`client` directory:
 
 ```bash
 npm run build
@@ -45,10 +46,14 @@ npm run preview
 ```
 
 ## Starting the server in production
-The server does not require a build step. From the `server` directory run:
+The server does not require its own build step. After building the client, the
+server will automatically serve the `dist` directory. From the `server`
+directory run:
 
 ```bash
 npm start
 ```
 Use the `PORT` environment variable to change the listening port if needed.
+Once the server is running you can access the game at
+`http://localhost:3001` (or your chosen port).
 

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const express = require('express');
 const http = require('http');
 const { Server } = require('socket.io');
@@ -12,6 +13,13 @@ const io = new Server(server, {
 });
 
 const game = new Game();
+
+// Serve the built client in production
+const clientDist = path.join(__dirname, '../client/dist');
+app.use(express.static(clientDist));
+app.get('*', (req, res) => {
+  res.sendFile(path.join(clientDist, 'index.html'));
+});
 
 io.on('connection', (socket) => {
   console.log('player connected', socket.id);


### PR DESCRIPTION
## Summary
- serve the built React client from the Express server
- clarify production instructions in the README

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_684396ffcad0832fab068f53f602993a