### PR TITLE
Improve card UI and selection

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,30 +3,98 @@ import { io } from 'socket.io-client';
 
 const socket = io('http://localhost:3001');
 
+function cardDisplay(card) {
+  const symbols = { c: '♣', d: '♦', h: '♥', s: '♠' };
+  return card ? `${card.rank}${symbols[card.suit]}` : '';
+}
+
 export default function App() {
   const [hand, setHand] = useState([]);
   const [state, setState] = useState(null);
+  const [selected, setSelected] = useState([]);
+  const [playerName, setPlayerName] = useState('');
 
   useEffect(() => {
-    socket.on('start', ({hand}) => setHand(hand));
+    socket.on('start', ({ hand }) => setHand(hand));
+    socket.on('hand', ({ hand }) => setHand(hand));
     socket.on('state', data => setState(data));
-    socket.on('joined', () => console.log('joined game'));
+    socket.on('joined', ({ name }) => setPlayerName(name));
     socket.emit('join');
     return () => {
       socket.disconnect();
-    }
+    };
   }, []);
 
+  const toggleCard = (index) => {
+    setSelected((sel) =>
+      sel.includes(index) ? sel.filter((i) => i !== index) : [...sel, index]
+    );
+  };
+
+  const playSelected = () => {
+    const cards = selected.map((i) => hand[i]);
+    if (cards.length > 0) {
+      socket.emit('play', cards);
+      setSelected([]);
+    }
+  };
+
+  const pass = () => {
+    socket.emit('pass');
+    setSelected([]);
+  };
+
+  const myTurn = state && state.currentTurn === playerName;
+
   return (
-    <div className="container mx-auto">
+    <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-4">Thirteen Game</h1>
+
       {state && (
-        <div className="mb-2">Current turn: {state.currentTurn}</div>
+        <div className="mb-4 space-y-2">
+          <div>Current turn: {state.currentTurn}</div>
+          <div className="flex gap-4">
+            {state.players.map((p) => (
+              <div key={p.name}>{p.name}: {p.handCount}</div>
+            ))}
+          </div>
+          {state.lastPlay && (
+            <div>
+              Last play: {state.lastPlay.player} - {state.lastPlay.cards.map(cardDisplay).join(' ')}
+            </div>
+          )}
+        </div>
       )}
-      <div className="flex flex-wrap gap-2">
-        {hand.map((c,i) => (
-          <div key={i} className="border p-2 bg-white">{c.rank}{c.suit}</div>
+
+      <div className="flex flex-wrap gap-2 mb-4">
+        {hand.map((c, i) => (
+          <div
+            key={i}
+            onClick={() => toggleCard(i)}
+            className={`w-12 h-16 border rounded flex items-center justify-center text-xl font-semibold cursor-pointer select-none
+              ${['d','h'].includes(c.suit) ? 'text-red-600' : 'text-black'}
+              ${selected.includes(i) ? 'bg-yellow-200 border-yellow-500 -translate-y-1' : 'bg-white'}`}
+          >
+            {cardDisplay(c)}
+          </div>
         ))}
+      </div>
+
+      <div className="space-x-2">
+        <button
+          onClick={playSelected}
+          disabled={!myTurn || selected.length === 0}
+          className="px-4 py-2 bg-blue-500 text-white rounded disabled:opacity-50"
+        >
+          Play Selected
+        </button>
+        <button
+          onClick={pass}
+          disabled={!myTurn}
+          className="px-4 py-2 bg-gray-300 rounded disabled:opacity-50"
+        >
+          Pass
+        </button>
       </div>
     </div>
   );

--- a/server/game.js
+++ b/server/game.js
@@ -76,9 +76,11 @@ class Game {
     for (let i=0;i<this.players.length;i++) {
       this.players[i].hand = deck.slice(i*13, (i+1)*13);
       this.players[i].socket.emit('start', {hand: this.players[i].hand});
+      this.players[i].socket.emit('hand', {hand: this.players[i].hand});
     }
     this.turnIndex = 0;
     this.currentSet = null;
+    this.broadcastState();
   }
 
   playCards(socket, cards) {
@@ -155,7 +157,10 @@ class Game {
       currentTurn: this.players[this.turnIndex]?.name,
       lastPlay: this.currentSet
     };
-    this.players.forEach(p => p.socket.emit('state', state));
+    this.players.forEach(p => {
+      p.socket.emit('state', state);
+      p.socket.emit('hand', { hand: p.hand });
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- show cards with suit symbols and nicer styling
- allow selecting cards and playing or passing
- broadcast each player's hand from the server after every action

## Testing
- `npm test` in `server` *(fails: no test specified)*
- `npm test` in `client` *(fails: missing script)*
- `npm run build` in `client` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_6843b2ec3ba8832f9ef43e30e2990067