### PR TITLE
Add name entry screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ cd client
 npm run dev
 ```
 Vite will provide a local development URL (usually http://localhost:5173).
+Open this URL in your browser and you'll be prompted to enter a name before
+joining the lobby.
 
 ## Building the client for production
 From the `client` directory, run:

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -13,13 +13,14 @@ export default function App() {
   const [state, setState] = useState(null);
   const [selected, setSelected] = useState([]);
   const [playerName, setPlayerName] = useState('');
+  const [nameInput, setNameInput] = useState('');
+  const [hasJoined, setHasJoined] = useState(false);
 
   useEffect(() => {
     socket.on('start', ({ hand }) => setHand(hand));
     socket.on('hand', ({ hand }) => setHand(hand));
     socket.on('state', data => setState(data));
     socket.on('joined', ({ name }) => setPlayerName(name));
-    socket.emit('join');
     return () => {
       socket.disconnect();
     };
@@ -44,7 +45,36 @@ export default function App() {
     setSelected([]);
   };
 
+  const joinGame = () => {
+    socket.emit('join', nameInput.trim() || undefined);
+    setHasJoined(true);
+  };
+
   const myTurn = state && state.currentTurn === playerName;
+
+  if (!playerName) {
+    return (
+      <div className="container mx-auto p-4">
+        <h1 className="text-2xl font-bold mb-4">Thirteen Game</h1>
+        <div className="space-y-2">
+          <input
+            type="text"
+            value={nameInput}
+            onChange={(e) => setNameInput(e.target.value)}
+            placeholder="Enter your name"
+            className="border rounded px-2 py-1"
+          />
+          <button
+            onClick={joinGame}
+            disabled={hasJoined}
+            className="px-4 py-2 bg-blue-500 text-white rounded disabled:opacity-50"
+          >
+            Join Game
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="container mx-auto p-4">


### PR DESCRIPTION
## Summary
- prompt the user for a name before joining the game
- mention the new name screen in the README

## Testing
- `npm test` in `server` *(fails: no test specified)*
- `npm test` in `client` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843bc1a3300832f9263cbc9ba548a2a