### PR TITLE
Fix manual join

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -29,7 +29,6 @@ export default function App() {
     socket.on('joined', ({ name }) => setPlayerName(name));
     socket.on('gameOver', ({ rankings }) => setRankings(rankings));
     socket.on('readyState', ({ ready }) => setReady(ready));
-    socket.emit('join');
     return () => {
       socket.disconnect();
     };


### PR DESCRIPTION
## Summary
- ensure players aren't auto-joined on page load

## Testing
- `npm run build` in `client`
- `npm start` in `server`

------
https://chatgpt.com/codex/tasks/task_e_6843c0dc7838832fac5cb767eb76bd07