### PR TITLE
Disallow 2s in sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains a simple multiplayer "Thirteen" card game with a separate server and client.
 
+## Gameplay Rules
+- Standard "Thirteen" mechanics are implemented.
+- Sequences may **not** include the rank `2`.
+
 ## Prerequisites
 - [Node.js](https://nodejs.org/) (version 16 or later)
 - npm (comes with Node.js)

--- a/server/game.js
+++ b/server/game.js
@@ -49,6 +49,7 @@ function highestCard(cards) {
 
 function isSequence(cards) {
   if (cards.length < 3) return false;
+  if (cards.some(c => c.rank === '2')) return false;
   for (let i = 1; i < cards.length; i++) {
     if (compareRank(cards[i].rank, cards[i - 1].rank) !== 1) return false;
   }
@@ -57,6 +58,7 @@ function isSequence(cards) {
 
 function isDoubleSequence(cards) {
   if (cards.length < 6 || cards.length % 2 !== 0) return false;
+  if (cards.some(c => c.rank === '2')) return false;
   for (let i = 0; i < cards.length; i += 2) {
     if (cards[i].rank !== cards[i + 1].rank) return false;
     if (i >= 2 && compareRank(cards[i].rank, cards[i - 2].rank) !== 1) return false;


### PR DESCRIPTION
## Summary
- prevent sequences from containing the rank 2
- document gameplay rule about sequences in README

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in client (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_6843c47bf170832fa19e4ef179352688