### PR TITLE
Add lobby creation with join/start controls

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -120,7 +120,7 @@ class Player {
 }
 
 class Game {
-  constructor() {
+  constructor(autoStart = true) {
     this.players = [];
     this.activePlayers = [];
     this.turnIndex = 0;
@@ -132,6 +132,7 @@ class Game {
     this.ready = new Set();
     this.gameActive = false;
     this.waitingForReady = false;
+    this.autoStart = autoStart;
   }
 
   addPlayer(socket, name) {
@@ -140,7 +141,7 @@ class Game {
     this.players.push(player);
     socket.emit('joined', {name: player.name});
     this.broadcastState();
-    if (!this.gameActive && !this.waitingForReady && this.players.length >= 2) {
+    if (this.autoStart && !this.gameActive && !this.waitingForReady && this.players.length >= 2) {
       this.start();
     }
   }

--- a/server/index.js
+++ b/server/index.js
@@ -6,34 +6,121 @@ const Game = require('./game');
 const app = express();
 const server = http.createServer(app);
 const io = new Server(server, {
-  cors: {
-    origin: '*',
-  }
+  cors: { origin: '*' }
 });
 
-const game = new Game();
+const lobbies = new Map();
 
-io.on('connection', (socket) => {
+function lobbyList() {
+  return Array.from(lobbies.values()).map(l => ({
+    id: l.id,
+    hostName: l.hostName,
+    players: l.game.players.map(p => p.name),
+    started: l.game.gameActive
+  }));
+}
+
+function broadcastLobbyList() {
+  io.emit('lobbyList', lobbyList());
+}
+
+function updateLobbyInfo(lobby) {
+  const data = {
+    id: lobby.id,
+    hostId: lobby.host,
+    hostName: lobby.hostName,
+    players: lobby.game.players.map(p => p.name),
+    started: lobby.game.gameActive
+  };
+  lobby.game.players.forEach(p => p.socket.emit('lobbyInfo', data));
+}
+
+io.on('connection', socket => {
   console.log('player connected', socket.id);
 
-  socket.on('join', (name) => {
-    game.addPlayer(socket, name);
+  socket.on('setName', name => {
+    socket.data.name = name || 'Player';
+    socket.emit('nameSet', { name: socket.data.name });
+    broadcastLobbyList();
   });
 
-  socket.on('play', (cards) => {
-    game.playCards(socket, cards);
+  socket.on('listLobbies', () => {
+    socket.emit('lobbyList', lobbyList());
+  });
+
+  socket.on('createLobby', () => {
+    if (!socket.data.name) return;
+    const id = Math.random().toString(36).slice(2, 8);
+    const lobby = {
+      id,
+      host: socket.id,
+      hostName: socket.data.name,
+      game: new Game(false)
+    };
+    lobbies.set(id, lobby);
+    lobby.game.addPlayer(socket, socket.data.name);
+    socket.data.lobbyId = id;
+    broadcastLobbyList();
+    updateLobbyInfo(lobby);
+  });
+
+  socket.on('joinLobby', id => {
+    const lobby = lobbies.get(id);
+    if (!lobby) return;
+    if (lobby.game.gameActive || lobby.game.players.length >= 4) return;
+    lobby.game.addPlayer(socket, socket.data.name);
+    socket.data.lobbyId = id;
+    broadcastLobbyList();
+    updateLobbyInfo(lobby);
+  });
+
+  socket.on('startGame', () => {
+    const lobby = lobbies.get(socket.data.lobbyId);
+    if (!lobby) return;
+    if (lobby.host !== socket.id) return;
+    if (!lobby.game.gameActive && lobby.game.players.length >= 2) {
+      lobby.game.start();
+      broadcastLobbyList();
+      updateLobbyInfo(lobby);
+    }
+  });
+
+  socket.on('play', cards => {
+    const lobby = lobbies.get(socket.data.lobbyId);
+    if (lobby) lobby.game.playCards(socket, cards);
   });
 
   socket.on('pass', () => {
-    game.pass(socket);
+    const lobby = lobbies.get(socket.data.lobbyId);
+    if (lobby) lobby.game.pass(socket);
   });
 
   socket.on('ready', () => {
-    game.readyUp(socket);
+    const lobby = lobbies.get(socket.data.lobbyId);
+    if (lobby) lobby.game.readyUp(socket);
   });
 
   socket.on('disconnect', () => {
-    game.removePlayer(socket);
+    const id = socket.data.lobbyId;
+    if (!id) return;
+    const lobby = lobbies.get(id);
+    if (!lobby) return;
+    lobby.game.removePlayer(socket);
+    if (lobby.host === socket.id) {
+      if (lobby.game.players.length > 0) {
+        lobby.host = lobby.game.players[0].socket.id;
+        lobby.hostName = lobby.game.players[0].name;
+      } else {
+        lobbies.delete(id);
+        broadcastLobbyList();
+        return;
+      }
+    }
+    if (lobby.game.players.length === 0) {
+      lobbies.delete(id);
+    }
+    broadcastLobbyList();
+    updateLobbyInfo(lobby);
   });
 });
 
@@ -41,3 +128,4 @@ const PORT = process.env.PORT || 3001;
 server.listen(PORT, () => {
   console.log(`Server listening on ${PORT}`);
 });
+


### PR DESCRIPTION
## Summary
- add `autoStart` flag to Game for manual control
- implement lobby management on server
- allow players to create and join lobbies from client UI
- provide lobby waiting page and host start control

## Testing
- `npm test` *(fails: `Could not read package.json`)*
- `cd server && npm test` *(fails: no tests specified)*
- `cd client && npm test` *(fails: Missing script: "test")*
- `cd client && npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843ce115590832fa5aaea992e1c2011