### PR TITLE
Colorized last play display

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -209,7 +209,16 @@ export default function App() {
           </div>
           {state.lastPlay && (
             <div>
-              Last play: {state.lastPlay.player} - {state.lastPlay.cards.map(cardDisplay).join(' ')}
+              Last play: {state.lastPlay.player} -{' '}
+              {state.lastPlay.cards.map((c, i) => (
+                <span
+                  key={i}
+                  className={['d', 'h'].includes(c.suit) ? 'text-red-600 font-semibold' : 'text-black font-semibold'}
+                >
+                  {cardDisplay(c)}
+                  {i < state.lastPlay.cards.length - 1 ? ' ' : ''}
+                </span>
+              ))}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- display last played cards in red or black based on suit

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843d81feff4832fa65b9b97797e5f16