### PR TITLE
Preserve client hand order

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -49,8 +49,27 @@ export default function App() {
     socket.on('start', ({ hand }) => {
       setRankings(null);
       setHand(hand);
+      setSelected([]);
     });
-    socket.on('hand', ({ hand }) => setHand(hand));
+    socket.on('hand', ({ hand: newHand }) => {
+      setHand(prev => {
+        const updated = prev.filter(card =>
+          newHand.some(c => c.rank === card.rank && c.suit === card.suit)
+        );
+        newHand.forEach(card => {
+          if (!updated.some(c => c.rank === card.rank && c.suit === card.suit)) {
+            updated.push(card);
+          }
+        });
+        setSelected(sel => {
+          const selectedCards = sel.map(i => prev[i]).filter(Boolean);
+          return selectedCards.map(card =>
+            updated.findIndex(c => c.rank === card.rank && c.suit === card.suit)
+          );
+        });
+        return updated;
+      });
+    });
     socket.on('state', data => setState(data));
     socket.on('gameOver', ({ rankings }) => setRankings(rankings));
     return () => {


### PR DESCRIPTION
## Summary
- preserve custom hand arrangement after server updates

## Testing
- `npm test` in `client` *(fails: Missing script)*
- `npm test` in `server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843da854374832fa3eb165d12fd130a