### PR TITLE
Add leave lobby button

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -126,6 +126,16 @@ export default function App() {
     socket.emit('startGame');
   };
 
+  const leaveLobby = () => {
+    socket.emit('leaveLobby');
+    setCurrentLobby(null);
+    setState(null);
+    setHand([]);
+    setSelected([]);
+    setRankings(null);
+    socket.emit('listLobbies');
+  };
+
   const myTurn = state && state.currentTurn === playerName;
 
   if (rankings) {
@@ -152,6 +162,14 @@ export default function App() {
             className="px-4 py-2 bg-green-500 text-white rounded"
           >
             Start New Game
+          </button>
+        )}
+        {currentLobby && (
+          <button
+            onClick={leaveLobby}
+            className="px-4 py-2 bg-red-500 text-white rounded"
+          >
+            Leave Lobby
           </button>
         )}
       </div>
@@ -229,6 +247,12 @@ export default function App() {
         ) : (
           <div>Waiting for {currentLobby.hostName} to start the game...</div>
         )}
+        <button
+          onClick={leaveLobby}
+          className="px-4 py-2 bg-red-500 text-white rounded"
+        >
+          Leave Lobby
+        </button>
       </div>
     );
   }
@@ -299,6 +323,12 @@ export default function App() {
           Sort Hand
         </button>
       </div>
+      <button
+        onClick={leaveLobby}
+        className="fixed bottom-4 right-4 px-4 py-2 bg-red-500 text-white rounded"
+      >
+        Leave Lobby
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `leaveLobby` event on server to allow players to leave without disconnecting
- expose `leaveLobby` action in the client
- show **Leave Lobby** button on lobby, game, and end game screens

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in client (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_6843dce19b90832fbdd74ca0467792e6