### PR TITLE
Add spectate mode and lobby status

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -250,12 +250,15 @@ export default function App() {
           <ul className="space-y-2">
             {lobbies.map(l => (
               <li key={l.id} className="flex items-center gap-2">
-                <span>{l.hostName} ({l.players.length}/4)</span>
+                <span>
+                  {l.hostName} ({l.players.length}/4) -{' '}
+                  {l.started ? 'In game' : 'Waiting'}
+                </span>
                 <button
                   onClick={() => joinLobby(l.id)}
                   className="px-2 py-1 bg-blue-500 text-white rounded"
                 >
-                  Join
+                  {l.started ? 'Spectate' : 'Join'}
                 </button>
               </li>
             ))}

--- a/server/index.js
+++ b/server/index.js
@@ -67,8 +67,12 @@ io.on('connection', socket => {
   socket.on('joinLobby', id => {
     const lobby = lobbies.get(id);
     if (!lobby) return;
-    if (lobby.game.gameActive || lobby.game.players.length >= 4) return;
-    lobby.game.addPlayer(socket, socket.data.name);
+    if (lobby.game.gameActive) {
+      lobby.game.addPlayer(socket, socket.data.name, true);
+    } else {
+      if (lobby.game.players.filter(p => !p.spectator).length >= 4) return;
+      lobby.game.addPlayer(socket, socket.data.name);
+    }
     socket.data.lobbyId = id;
     broadcastLobbyList();
     updateLobbyInfo(lobby);


### PR DESCRIPTION
## Summary
- show lobby status and spectate button in lobby list
- allow joining as spectator while a game is running
- spectators automatically join the next game

## Testing
- `npm test` (fails: no test specified)
- `npm test` in client (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_e_6843e04a3ff8832fb79942817246ee8c