### PR TITLE
Implement play again lobby flow

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -108,6 +108,12 @@ export default function App() {
         setLastWinner(rankings[0]);
       }
     });
+    socket.on('returnToLobby', () => {
+      setRankings(null);
+      setState(null);
+      setHand([]);
+      setSelected([]);
+    });
     return () => {
       socket.disconnect();
     };
@@ -194,10 +200,10 @@ export default function App() {
         </ol>
         {currentLobby && currentLobby.hostId === socket.id && (
           <button
-            onClick={startGame}
+            onClick={() => socket.emit('returnToLobby')}
             className="px-4 py-2 bg-green-500 text-white rounded"
           >
-            Start New Game
+            Play Again
           </button>
         )}
         {currentLobby && (

--- a/server/index.js
+++ b/server/index.js
@@ -89,6 +89,20 @@ io.on('connection', socket => {
     }
   });
 
+  socket.on('returnToLobby', () => {
+    const lobby = lobbies.get(socket.data.lobbyId);
+    if (!lobby) return;
+    if (lobby.host !== socket.id) return;
+    if (!lobby.game.gameActive) return;
+    lobby.game.waitingForReady = false;
+    lobby.game.ready.clear();
+    lobby.game.rankings = [];
+    lobby.game.gameActive = false;
+    broadcastLobbyList();
+    updateLobbyInfo(lobby);
+    lobby.game.players.forEach(p => p.socket.emit('returnToLobby'));
+  });
+
   socket.on('play', cards => {
     const lobby = lobbies.get(socket.data.lobbyId);
     if (lobby) lobby.game.playCards(socket, cards);


### PR DESCRIPTION
## Summary
- replace end-of-game "Start New Game" button with "Play Again"
- add client handler for `returnToLobby` to reset state
- add `returnToLobby` socket event on server to show lobby after game

## Testing
- `npm test` in `server` *(fails: Error: no test specified)*
- `npm test` in `client` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843e2b50a18832fbc6685d1f013641d