### PR TITLE
Use Render URL in production build

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,10 @@ npm start
 ```
 Use the `PORT` environment variable to change the listening port if needed.
 
+## Client/server URL
+
+During development the client connects to `http://localhost:3001`. When you
+build the client for production, it automatically uses
+`https://playonethree-1.onrender.com` as the Socket.IO server URL. If you deploy
+the server somewhere else, edit `client/src/App.jsx` to point at your server.
+

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,7 +2,11 @@ import React, { useEffect, useState, useRef } from 'react';
 import { io } from 'socket.io-client';
 import confetti from 'canvas-confetti';
 
-const socket = io('http://localhost:3001');
+const socket = io(
+  import.meta.env.PROD
+    ? 'https://playonethree-1.onrender.com'
+    : 'http://localhost:3001'
+);
 
 function cardDisplay(card) {
   const symbols = { c: '♣', d: '♦', h: '♥', s: '♠' };


### PR DESCRIPTION
## Summary
- update socket.io client to switch between localhost and Render URL depending on build mode
- document the production URL in the README

## Testing
- `npm run build` within `client`
- `npm test` within `server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843e329c01c832f8d21ca0154126ef5