### PR TITLE
Fix play again button and add lobby button

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -182,6 +182,13 @@ export default function App() {
     socket.emit('listLobbies');
   };
 
+  const goToLobby = () => {
+    setRankings(null);
+    setState(null);
+    setHand([]);
+    setSelected([]);
+  };
+
   const myTurn = state && state.currentTurn === playerName;
 
   if (rankings) {
@@ -208,6 +215,14 @@ export default function App() {
             className="px-4 py-2 bg-green-500 text-white rounded"
           >
             Play Again
+          </button>
+        )}
+        {currentLobby && currentLobby.hostId !== socket.id && (
+          <button
+            onClick={goToLobby}
+            className="px-4 py-2 bg-green-500 text-white rounded"
+          >
+            Go to Lobby
           </button>
         )}
         {currentLobby && (

--- a/server/index.js
+++ b/server/index.js
@@ -93,7 +93,7 @@ io.on('connection', socket => {
     const lobby = lobbies.get(socket.data.lobbyId);
     if (!lobby) return;
     if (lobby.host !== socket.id) return;
-    if (!lobby.game.gameActive) return;
+    if (!lobby.game.gameActive && !lobby.game.waitingForReady) return;
     lobby.game.waitingForReady = false;
     lobby.game.ready.clear();
     lobby.game.rankings = [];


### PR DESCRIPTION
## Summary
- fix server condition so host can send `returnToLobby` after a game finishes
- add a `goToLobby` button for non-hosts on the game over screen

## Testing
- `npm install` in `client`
- `npm install` in `server`
- `npm start` in `server`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6843f1298f14832f8e958b955423175a