### PR TITLE
UI overhaul

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -6,7 +6,7 @@
     <title>Thirteen Game</title>
     <script type="module" src="/src/main.jsx"></script>
   </head>
-  <body class="bg-gray-100 p-4">
+  <body class="min-h-screen p-4 bg-green-600 pattern-bubbles overflow-hidden">
     <div id="root"></div>
   </body>
 </html>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,3 +1,19 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* background bubble pattern */
+.pattern-bubbles {
+  background-image: radial-gradient(rgba(255,255,255,0.15) 2px, transparent 2px),
+    radial-gradient(rgba(255,255,255,0.15) 2px, transparent 2px);
+  background-size: 50px 50px;
+  background-position: 0 0, 25px 25px;
+}
+
+@keyframes spin-slow {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+.animate-spin-slow {
+  animation: spin-slow 6s linear infinite;
+}


### PR DESCRIPTION
## Summary
- overhaul design with UNO-inspired table layout
- add animated bubble background and arrow indicator
- show player avatars, deck and discard pile images
- fan player hand with card images

## Testing
- `npm install` in both client and server
- `npm run build` in client

------
https://chatgpt.com/codex/tasks/task_e_68444ed4714c832fa57d6d61934694c3