### PR TITLE
Adjust action button position

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -477,7 +477,11 @@ export default function App() {
           })}
         </div>
         <div
-          className={`absolute z-30 ${isMobile ? 'left-1/2 -translate-x-1/2 bottom-36' : 'right-2 bottom-2'} flex flex-col items-center`}
+          className={`absolute z-30 ${
+            isMobile
+              ? 'left-1/2 -translate-x-1/2 bottom-36'
+              : 'right-2 bottom-2 sm:bottom-4'
+          } flex flex-col items-center`}
         >
           <div className={`flex ${isMobile ? 'flex-row gap-2' : 'flex-row gap-2'}`}>
             <button


### PR DESCRIPTION
## Summary
- elevate action buttons in desktop view so they're not flush with bottom

## Testing
- `npm --prefix client run build`

------
https://chatgpt.com/codex/tasks/task_e_68448ee789bc832f9d4eb873323b34d0