### PR TITLE
Improve name entry screen

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,9 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Thirteen Game</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet" />
     <script type="module" src="/src/main.jsx"></script>
   </head>
-  <body class="min-h-screen p-4 bg-green-700 overflow-hidden">
+  <body class="min-h-screen p-4 bg-neutral-200 overflow-hidden">
     <div id="root"></div>
   </body>
 </html>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -297,8 +297,16 @@ export default function App() {
 
   if (!playerName) {
     return (
-      <div className="container mx-auto p-4">
-        <h1 className="text-2xl font-bold mb-4">Thirteen Game</h1>
+      <div className="min-h-screen flex flex-col items-center justify-center">
+        <motion.h1
+          initial={{ scale: 0.9, opacity: 0 }}
+          animate={{ scale: 1.1, opacity: 1 }}
+          transition={{ type: 'spring', stiffness: 120 }}
+          className="text-4xl font-extrabold mb-6 text-transparent bg-clip-text bg-gradient-to-r from-purple-500 via-pink-500 to-red-500 drop-shadow"
+          style={{ fontFamily: '"Pacifico", cursive' }}
+        >
+          Thirteen Game
+        </motion.h1>
         <div className="space-y-2">
           <input
             type="text"


### PR DESCRIPTION
## Summary
- center the initial name entry screen
- add a decorative animated title
- switch app background to a neutral color
- pull in a Google Font for the title text

## Testing
- `npm run build` in `client`
- `npm test` in `server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68448f5df59c832fb53ef5b490f98ecd