### PR TITLE
Fix board to display all cards in last play

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -411,19 +411,22 @@ export default function App() {
         <div className="relative mx-auto w-full max-w-md sm:max-w-lg md:max-w-4xl h-[22rem] sm:h-[28rem] md:h-[32rem] rounded-full bg-gradient-to-b from-orange-600 via-red-500 to-orange-400 shadow-inner">
           <img src={CARD_BACK} alt="Deck" className="absolute w-16 left-4 top-1/2 -translate-y-1/2" />
           {state.lastPlay && (
-            state.lastPlay.cards.slice(-4).map((c, i, arr) => (
-              <img
-                key={i}
-                src={cardImageUrl(c)}
-                alt={cardDisplay(c)}
-                className="absolute w-16 bg-white rounded-sm"
-                style={{
-                  left: '50%',
-                  top: '50%',
-                  transform: `translate(-50%,-50%) rotate(${(i-(arr.length-1)/2)*10}deg) translateX(${(i-(arr.length-1)/2)*10}px)`
-                }}
-              />
-            ))
+            state.lastPlay.cards.map((c, i, arr) => {
+              const offset = i - (arr.length - 1) / 2;
+              return (
+                <img
+                  key={i}
+                  src={cardImageUrl(c)}
+                  alt={cardDisplay(c)}
+                  className="absolute w-16 bg-white rounded-sm"
+                  style={{
+                    left: '50%',
+                    top: '50%',
+                    transform: `translate(-50%,-50%) rotate(${offset * 10}deg) translateX(${offset * 10}px)`
+                  }}
+                />
+              );
+            })
           )}
           {state.players.map((p, idx) => {
             const myIndex = state.players.findIndex(pl => pl.name === playerName);


### PR DESCRIPTION
## Summary
- show every card of the last play on the board instead of only the last 4

## Testing
- `npm run build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844912faf4c832fb509ba8d5e4dad8d