### PR TITLE
Fix Game title clipping

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet" />
     <script type="module" src="/src/main.jsx"></script>
   </head>
-  <body class="min-h-screen p-4 bg-neutral-200 overflow-hidden">
+  <body class="min-h-screen p-4 bg-neutral-200">
     <div id="root"></div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- stop clipping bottom of gradient title text by removing `overflow-hidden` on the HTML body

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844914d7350832f86dc66f3576aaa1c