### PR TITLE
Fix avatar visibility and sticky action buttons

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -492,11 +492,11 @@ export default function App() {
           })}
         </div>
         <div
-          className={`absolute z-30 ${
+          className={`${
             isMobile
-              ? 'left-1/2 -translate-x-1/2 bottom-36'
-              : 'right-2 bottom-2 sm:bottom-4'
-          } flex flex-col items-center`}
+              ? 'absolute left-1/2 -translate-x-1/2 bottom-36'
+              : 'fixed right-2 bottom-2 sm:bottom-4'
+          } z-30 flex flex-col items-center`}
         >
           <div className="flex flex-row gap-2">
             <button
@@ -530,7 +530,7 @@ export default function App() {
         </>
       )}
       {state && (
-        <div className="fixed bottom-2 left-2 sm:bottom-4 sm:left-4 flex items-center gap-2 text-gray-800">
+        <div className="fixed bottom-2 left-2 sm:bottom-4 sm:left-4 flex items-center gap-2 text-gray-800 z-40">
           <div
             className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full flex items-center justify-center font-bold ${myTurn ? 'glowing-turn' : ''}`}
             style={{ backgroundColor: avatarColor(playerName) }}


### PR DESCRIPTION
## Summary
- keep avatar above hand on mobile by adding z-index
- make action buttons fixed on desktop

## Testing
- `npm install` within `client`
- `npm run build` within `client`

------
https://chatgpt.com/codex/tasks/task_e_684496404068832fb2b2646ec1a5ae28