### PR TITLE
Add sorting animation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -469,9 +469,12 @@ export default function App() {
                       const isSelected = selected.includes(i);
                       const isHovered = hovered === i;
                       const y = drop - (isSelected ? 32 : 0) - (isHovered ? 8 : 0);
+                      const id = `${c.rank}${c.suit}`;
                       return (
                         <motion.img
-                          key={i}
+                          key={id}
+                          layout
+                          transition={{ type: 'spring', stiffness: 500, damping: 30 }}
                           src={cardImageUrl(c)}
                           alt={cardDisplay(c)}
                           onClick={() => toggleCard(i)}


### PR DESCRIPTION
## Summary
- animate card rearranging when sorting

## Testing
- `npm run build` in `client/`

------
https://chatgpt.com/codex/tasks/task_e_6844a782afcc832fbc7d907cfa6233cc