### PR TITLE
Add sorting animation

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "framer-motion": "^11.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-flip-toolkit": "^7.2.4",
         "socket.io-client": "^4.8.1"
       },
       "devDependencies": {
@@ -1696,6 +1697,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/flip-toolkit": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/flip-toolkit/-/flip-toolkit-7.2.4.tgz",
+      "integrity": "sha512-NT81ikyHPk72riMe1U01x698YIMSypMF5mQBhRklWVgf2xgWH3EPfrrVRAkz/+TSCq0rLPsr/uKIYkwHrowKZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "rematrix": "0.2.2"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2155,7 +2169,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2402,6 +2415,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2448,6 +2472,30 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-flip-toolkit": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/react-flip-toolkit/-/react-flip-toolkit-7.2.4.tgz",
+      "integrity": "sha512-+aZBZwzHBDfJzMRLjAAOKiBkrk8PV0YFVE0k1x85+UsykApLwg8a0LlQ5H80uFltFZmGtrQ7EE1krhiZ1jI5ig==",
+      "license": "MIT",
+      "dependencies": {
+        "flip-toolkit": "7.2.4",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": ">= 16.x",
+        "react-dom": ">= 16.x"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2480,6 +2528,12 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/rematrix": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/rematrix/-/rematrix-0.2.2.tgz",
+      "integrity": "sha512-agFFS3RzrLXJl5LY5xg/xYyXvUuVAnkhgKO7RaO9J1Ssth6yvbO+PIiV67V59MB5NCdAK2flvGvNT4mdKVniFA==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,7 +12,6 @@
         "framer-motion": "^11.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-flip-toolkit": "^7.2.4",
         "socket.io-client": "^4.8.1"
       },
       "devDependencies": {
@@ -1697,19 +1696,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/flip-toolkit": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/flip-toolkit/-/flip-toolkit-7.2.4.tgz",
-      "integrity": "sha512-NT81ikyHPk72riMe1U01x698YIMSypMF5mQBhRklWVgf2xgWH3EPfrrVRAkz/+TSCq0rLPsr/uKIYkwHrowKZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "rematrix": "0.2.2"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      }
-    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2169,6 +2155,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2415,17 +2402,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2472,30 +2448,6 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-flip-toolkit": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/react-flip-toolkit/-/react-flip-toolkit-7.2.4.tgz",
-      "integrity": "sha512-+aZBZwzHBDfJzMRLjAAOKiBkrk8PV0YFVE0k1x85+UsykApLwg8a0LlQ5H80uFltFZmGtrQ7EE1krhiZ1jI5ig==",
-      "license": "MIT",
-      "dependencies": {
-        "flip-toolkit": "7.2.4",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      },
-      "peerDependencies": {
-        "react": ">= 16.x",
-        "react-dom": ">= 16.x"
-      }
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2528,12 +2480,6 @@
       "engines": {
         "node": ">=8.10.0"
       }
-    },
-    "node_modules/rematrix": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/rematrix/-/rematrix-0.2.2.tgz",
-      "integrity": "sha512-agFFS3RzrLXJl5LY5xg/xYyXvUuVAnkhgKO7RaO9J1Ssth6yvbO+PIiV67V59MB5NCdAK2flvGvNT4mdKVniFA==",
-      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/client/package.json
+++ b/client/package.json
@@ -9,11 +9,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "canvas-confetti": "^1.9.0",
+    "framer-motion": "^11.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "socket.io-client": "^4.8.1",
-    "canvas-confetti": "^1.9.0",
-    "framer-motion": "^11.0.0"
+    "react-flip-toolkit": "^7.2.4",
+    "socket.io-client": "^4.8.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.5.1",

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,6 @@
     "framer-motion": "^11.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-flip-toolkit": "^7.2.4",
     "socket.io-client": "^4.8.1"
   },
   "devDependencies": {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -90,8 +90,6 @@ export default function App() {
   const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 430);
   // Used to trigger sort animations
   const [sortTrigger, setSortTrigger] = useState(0);
-  // Whether the hand should be displayed in a fanned layout
-  const [fanned, setFanned] = useState(false);
   // Stage of the sort animation
   const [sortStage, setSortStage] = useState('none');
 
@@ -129,7 +127,6 @@ export default function App() {
       setLastWinner(null);
       setHand(hand);
       setSelected([]);
-      setFanned(false);
     });
     socket.on('hand', ({ hand: newHand }) => {
       setHand(prev => {
@@ -211,11 +208,10 @@ export default function App() {
       setSortTrigger(t => t + 1);
       setSortStage('swap');
       setTimeout(() => {
-        setFanned(true);
         setSortStage('drop');
-        setTimeout(() => setSortStage('none'), 400);
-      }, 400);
-    }, 300);
+        setTimeout(() => setSortStage('none'), 600);
+      }, 600);
+    }, 600);
   };
 
   const setName = () => {
@@ -479,18 +475,17 @@ export default function App() {
                 )}
                 {pos === 'bottom' && (
                   <div className="relative h-40 sm:h-56 mt-2 flex items-end justify-center w-full z-20" style={{ perspective: '800px' }}>
-                    <Flipper flipKey={sortTrigger} spring={{ stiffness: 500, damping: 30 }}>
+                    <Flipper flipKey={sortTrigger} spring={{ stiffness: 120, damping: 40 }}>
                       {hand.map((c,i) => {
-                        const angle = fanned ? (i - (hand.length - 1) / 2) * 8 : 0;
-                        const tilt = fanned ? -angle * 0.3 : 0;
+                        const angle = 0;
+                        const tilt = 0;
                         const baseSpacing = isMobile ? 16 : 32;
                         const spacing = sortStage === 'raise' || sortStage === 'swap' ? baseSpacing * 2 : baseSpacing;
                         const shift = (i - (hand.length - 1) / 2) * spacing;
-                        const drop = fanned ? Math.abs(angle) * 1.2 : 0;
                         const raise = sortStage === 'raise' || sortStage === 'swap' ? -80 : 0;
                         const isSelected = selected.includes(i);
                         const isHovered = hovered === i;
-                        const y = raise + drop - (isSelected ? 32 : 0) - (isHovered ? 8 : 0);
+                        const y = raise - (isSelected ? 32 : 0) - (isHovered ? 8 : 0);
                         const id = `${c.rank}${c.suit}`;
                         return (
                           <Flipped key={id} flipId={id}>
@@ -505,7 +500,7 @@ export default function App() {
                                 transform: `translate(-50%, ${y}px) rotateY(${tilt}deg) rotate(${angle}deg)`,
                                 left: `calc(50% + ${shift}px)`
                               }}
-                              transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+                              transition={{ duration: 0.6, ease: 'easeInOut' }}
                             />
                           </Flipped>
                         );

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { motion } from 'framer-motion';
+import { Flipper, Flipped } from 'react-flip-toolkit';
 import { io } from 'socket.io-client';
 import confetti from 'canvas-confetti';
 
@@ -87,6 +88,8 @@ export default function App() {
   const [currentLobby, setCurrentLobby] = useState(null);
   // Treat widths up to 430px (iPhone 13 Pro) as mobile
   const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 430);
+  // Used to trigger sort animations
+  const [sortTrigger, setSortTrigger] = useState(0);
 
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth <= 430);
@@ -197,6 +200,7 @@ export default function App() {
       });
       return sorted;
     });
+    setSortTrigger(t => t + 1);
   };
 
   const setName = () => {
@@ -460,31 +464,35 @@ export default function App() {
                 )}
                 {pos === 'bottom' && (
                   <div className="relative h-40 sm:h-56 mt-2 flex items-end justify-center w-full z-20" style={{ perspective: '800px' }}>
-                    {hand.map((c,i) => {
-                      const angle = (i - (hand.length - 1) / 2) * 8;
-                      const tilt = -angle * 0.3;
-                      const spacing = isMobile ? 16 : 32;
-                      const shift = (i - (hand.length - 1) / 2) * spacing;
-                      const drop = Math.abs(angle) * 1.2;
-                      const isSelected = selected.includes(i);
-                      const isHovered = hovered === i;
-                      const y = drop - (isSelected ? 32 : 0) - (isHovered ? 8 : 0);
-                      return (
-                        <motion.img
-                          key={i}
-                          src={cardImageUrl(c)}
-                          alt={cardDisplay(c)}
-                          onClick={() => toggleCard(i)}
-                          onMouseEnter={() => setHovered(i)}
-                          onMouseLeave={() => setHovered(null)}
-                          className={`${isMobile ? 'w-16' : 'w-20 sm:w-24 md:w-28'} absolute transition-transform drop-shadow-lg cursor-pointer bottom-0 rounded-sm bg-white ${isSelected ? 'border-4 border-yellow-300' : ''}`}
-                          style={{
-                            transform: `translate(-50%, ${y}px) rotateY(${tilt}deg) rotate(${angle}deg)`,
-                            left: `calc(50% + ${shift}px)`
-                          }}
-                        />
-                      );
-                    })}
+                    <Flipper flipKey={sortTrigger} spring={{ stiffness: 500, damping: 30 }}>
+                      {hand.map((c,i) => {
+                        const angle = (i - (hand.length - 1) / 2) * 8;
+                        const tilt = -angle * 0.3;
+                        const spacing = isMobile ? 16 : 32;
+                        const shift = (i - (hand.length - 1) / 2) * spacing;
+                        const drop = Math.abs(angle) * 1.2;
+                        const isSelected = selected.includes(i);
+                        const isHovered = hovered === i;
+                        const y = drop - (isSelected ? 32 : 0) - (isHovered ? 8 : 0);
+                        const id = `${c.rank}${c.suit}`;
+                        return (
+                          <Flipped key={id} flipId={id}>
+                            <motion.img
+                              src={cardImageUrl(c)}
+                              alt={cardDisplay(c)}
+                              onClick={() => toggleCard(i)}
+                              onMouseEnter={() => setHovered(i)}
+                              onMouseLeave={() => setHovered(null)}
+                              className={`${isMobile ? 'w-16' : 'w-20 sm:w-24 md:w-28'} absolute transition-transform drop-shadow-lg cursor-pointer bottom-0 rounded-sm bg-white ${isSelected ? 'border-4 border-yellow-300' : ''}`}
+                              style={{
+                                transform: `translate(-50%, ${y}px) rotateY(${tilt}deg) rotate(${angle}deg)`,
+                                left: `calc(50% + ${shift}px)`
+                              }}
+                            />
+                          </Flipped>
+                        );
+                      })}
+                    </Flipper>
                   </div>
                 )}
               </div>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -90,6 +90,8 @@ export default function App() {
   const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 430);
   // Used to trigger sort animations
   const [sortTrigger, setSortTrigger] = useState(0);
+  // Whether the hand should be displayed in a fanned layout
+  const [fanned, setFanned] = useState(false);
 
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth <= 430);
@@ -125,6 +127,7 @@ export default function App() {
       setLastWinner(null);
       setHand(hand);
       setSelected([]);
+      setFanned(false);
     });
     socket.on('hand', ({ hand: newHand }) => {
       setHand(prev => {
@@ -201,6 +204,7 @@ export default function App() {
       return sorted;
     });
     setSortTrigger(t => t + 1);
+    setFanned(true);
   };
 
   const setName = () => {
@@ -466,11 +470,11 @@ export default function App() {
                   <div className="relative h-40 sm:h-56 mt-2 flex items-end justify-center w-full z-20" style={{ perspective: '800px' }}>
                     <Flipper flipKey={sortTrigger} spring={{ stiffness: 500, damping: 30 }}>
                       {hand.map((c,i) => {
-                        const angle = (i - (hand.length - 1) / 2) * 8;
-                        const tilt = -angle * 0.3;
+                        const angle = fanned ? (i - (hand.length - 1) / 2) * 8 : 0;
+                        const tilt = fanned ? -angle * 0.3 : 0;
                         const spacing = isMobile ? 16 : 32;
                         const shift = (i - (hand.length - 1) / 2) * spacing;
-                        const drop = Math.abs(angle) * 1.2;
+                        const drop = fanned ? Math.abs(angle) * 1.2 : 0;
                         const isSelected = selected.includes(i);
                         const isHovered = hovered === i;
                         const y = drop - (isSelected ? 32 : 0) - (isHovered ? 8 : 0);

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -493,14 +493,10 @@ export default function App() {
                               onClick={() => toggleCard(i)}
                               onMouseEnter={() => setHovered(i)}
                               onMouseLeave={() => setHovered(null)}
-                              className={`${isMobile ? 'w-16' : 'w-20 sm:w-24 md:w-28'} absolute drop-shadow-lg cursor-pointer bottom-0 rounded-sm bg-white ${isSelected ? 'border-4 border-yellow-300' : ''}`}
-                              animate={{
+                              className={`${isMobile ? 'w-16' : 'w-20 sm:w-24 md:w-28'} absolute transition-transform drop-shadow-lg cursor-pointer bottom-0 rounded-sm bg-white ${isSelected ? 'border-4 border-yellow-300' : ''}`}
+                              style={{
                                 transform: `translate(-50%, ${y}px) rotateY(${tilt}deg) rotate(${angle}deg)`,
                                 left: `calc(50% + ${shift}px)`
-                              }}
-                              transition={{
-                                duration: sortStage === 'none' ? 0.2 : SORT_DURATION / 1000,
-                                ease: 'easeInOut'
                               }}
                             />
                         );

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -92,6 +92,7 @@ export default function App() {
   const [sortTrigger, setSortTrigger] = useState(0);
   // Stage of the sort animation
   const [sortStage, setSortStage] = useState('none');
+  const SORT_DURATION = 800;
 
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth <= 430);
@@ -209,9 +210,9 @@ export default function App() {
       setSortStage('swap');
       setTimeout(() => {
         setSortStage('drop');
-        setTimeout(() => setSortStage('none'), 600);
-      }, 600);
-    }, 600);
+        setTimeout(() => setSortStage('none'), SORT_DURATION);
+      }, SORT_DURATION);
+    }, SORT_DURATION);
   };
 
   const setName = () => {
@@ -475,7 +476,7 @@ export default function App() {
                 )}
                 {pos === 'bottom' && (
                   <div className="relative h-40 sm:h-56 mt-2 flex items-end justify-center w-full z-20" style={{ perspective: '800px' }}>
-                    <Flipper flipKey={sortTrigger} spring={{ stiffness: 120, damping: 40 }}>
+                    <Flipper flipKey={sortTrigger} spring="noWobble">
                       {hand.map((c,i) => {
                         const angle = 0;
                         const tilt = 0;
@@ -500,7 +501,10 @@ export default function App() {
                                 transform: `translate(-50%, ${y}px) rotateY(${tilt}deg) rotate(${angle}deg)`,
                                 left: `calc(50% + ${shift}px)`
                               }}
-                              transition={{ duration: 0.6, ease: 'easeInOut' }}
+                              transition={{
+                                duration: sortStage === 'none' ? 0.2 : SORT_DURATION / 1000,
+                                ease: 'easeInOut'
+                              }}
                             />
                           </Flipped>
                         );

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -486,13 +486,14 @@ export default function App() {
                         const y = raise - (isSelected ? 32 : 0) - (isHovered ? 8 : 0);
                         const id = `${c.rank}${c.suit}`;
                         return (
-                            <motion.img layout
+                            <motion.img layout layoutId={id}
                               key={id}
                               src={cardImageUrl(c)}
                               alt={cardDisplay(c)}
                               onClick={() => toggleCard(i)}
                               onMouseEnter={() => setHovered(i)}
                               onMouseLeave={() => setHovered(null)}
+                              transition={{ type: 'tween', duration: SORT_DURATION / 1000 }}
                               className={`${isMobile ? 'w-16' : 'w-20 sm:w-24 md:w-28'} absolute transition-transform drop-shadow-lg cursor-pointer bottom-0 rounded-sm bg-white ${isSelected ? 'border-4 border-yellow-300' : ''}`}
                               style={{
                                 transform: `translate(-50%, ${y}px) rotateY(${tilt}deg) rotate(${angle}deg)`,


### PR DESCRIPTION
## Summary
- animate card rearranging when sorting using react-flip-toolkit
- keep hover/selection interactions unchanged

## Testing
- `npm run build` in `client/`


------
https://chatgpt.com/codex/tasks/task_e_6844a782afcc832fbc7d907cfa6233cc